### PR TITLE
add schemas for single sensor metrology

### DIFF
--- a/schemas/sensor_abs_height.schema
+++ b/schemas/sensor_abs_height.schema
@@ -1,0 +1,8 @@
+# -*- python -*-
+{
+    'schema_name' : 'sensor_abs_height',
+    'schema_version' : 0,
+    'z_median_m_13' : float,
+    'z_quantile_0975' : float,
+    'z_quantile_0025' : float
+}

--- a/schemas/sensor_edge_scan.schema
+++ b/schemas/sensor_edge_scan.schema
@@ -1,0 +1,6 @@
+# -*- python -*-
+{
+    'schema_name' : 'sensor_edge_scan',
+    'schema_version' : 0,
+    'grade' : str
+}

--- a/schemas/sensor_flatness.schema
+++ b/schemas/sensor_flatness.schema
@@ -1,0 +1,6 @@
+# -*- python -*-
+{
+    'schema_name' : 'sensor_flatness',
+    'schema_version' : 0,
+    'peak_valley_95' : float
+}


### PR DESCRIPTION
These should be used in the metrology validator scripts to persist the results to the eT db tables so that the web-based test reports can be generated.
