### PR TITLE
rollback usage of getProcessName in getSensorGains

### DIFF
--- a/python/eotestUtils.py
+++ b/python/eotestUtils.py
@@ -19,7 +19,7 @@ def getSensorGains(jobname='fe55_analysis', sensor_id=None):
         sensor_id = siteUtils.getUnitId()
     try:
         gain_file = dependency_glob('%s_eotest_results.fits' % sensor_id,
-                                    jobname=siteUtils.getProcessName(jobname))[0]
+                                    jobname=jobname)[0]
     except IndexError:
         raise RuntimeError('eotestUtils.getSensorGains: %s %s'
                            % (sensor_id, jobname))

--- a/python/siteUtils.py
+++ b/python/siteUtils.py
@@ -390,7 +390,15 @@ def make_png_file(callback, png_file, *args, **kwds):
         plt.clf()
 
 def png_data_product(pngfile, lsst_num):
-    return pngfile[len(lsst_num)+1:-len('.png')]
+    file_prefix = lsst_num
+    try:
+        my_prefix = '_'.join((lsst_num, getRunNumber()))
+        if pngfile.startswith(my_prefix):
+            file_prefix = my_prefix
+    except KeyError as eobj:
+        # Run number not available.
+        pass
+    return pngfile[len(file_prefix)+1:-len('.png')]
 
 def persist_png_files(file_pattern, lsst_id, folder=None, metadata=None):
     if metadata is None:

--- a/tests/test_siteUtils.py
+++ b/tests/test_siteUtils.py
@@ -49,5 +49,26 @@ class PackageVersionSummaryTestCase(unittest.TestCase):
                          "/nfs/farm/g/lsst/u1/software/datacat/config.cfg")
         self.assertEqual(len(versions), 11)
 
+class PngDataProductTestCase(unittest.TestCase):
+    "TestCase class for png data product handling code."
+    def setUp(self):
+        pass
+    def tearDown(self):
+        pass
+    def test_png_data_product(self):
+        data_product = 'median_dark'
+        lsst_num = 'E2V-CCD250-264'
+
+        run_number = '4005D'
+        os.environ['LCATR_RUN_NUMBER'] = run_number
+        pngfile = '%s_%s_%s.png' % (lsst_num, run_number, data_product)
+        self.assertEqual(siteUtils.png_data_product(pngfile, lsst_num),
+                         data_product)
+
+        del os.environ['LCATR_RUN_NUMBER']
+        pngfile = '%s_%s.png' % (lsst_num, data_product)
+        self.assertEqual(siteUtils.png_data_product(pngfile, lsst_num),
+                         data_product)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Needed by [LSSTTD-1032](https://jira.slac.stanford.edu/browse/LSSTTD-1032).