### PR TITLE
use exptime only as stand-in for integrated incident flux,

### DIFF
--- a/BNL_T03/flat_pairs/v0/producer_flat_pairs.py
+++ b/BNL_T03/flat_pairs/v0/producer_flat_pairs.py
@@ -12,4 +12,4 @@ mask_files = eotestUtils.glob_mask_files()
 gains = eotestUtils.getSensorGains()
 
 task = sensorTest.FlatPairTask()
-task.run(sensor_id, flat_files, mask_files, gains)
+task.run(sensor_id, flat_files, mask_files, gains, use_exptime=True)

--- a/BNL_T03/test_report/v0/producer_test_report.py
+++ b/BNL_T03/test_report/v0/producer_test_report.py
@@ -90,11 +90,12 @@ plt.close('all')
 # Linearity plots
 detresp_file = processName_dependencyGlob('%s_det_response.fits' % sensor_id,
                                           jobname='flat_pairs')[0]
-plots.linearity(ptc_file=ptc_file, detresp_file=detresp_file)
+plots.linearity(ptc_file=ptc_file, detresp_file=detresp_file, use_exptime=True)
 plt.savefig('%s_linearity.png' % sensor_id)
 plt.close('all')
 
-plots.linearity_resids(ptc_file=ptc_file, detresp_file=detresp_file)
+plots.linearity_resids(ptc_file=ptc_file, detresp_file=detresp_file,
+                       use_exptime=True)
 plt.savefig('%s_linearity_resids.png' % sensor_id)
 plt.close('all')
 


### PR DESCRIPTION
 i.e., neglect MONDIODE value